### PR TITLE
Add StaticRTTI accessor to RTTI macros

### DIFF
--- a/SuperStar/Game/Code/InGame/Component/Renderer/InGameRendererBaseComponent.cpp
+++ b/SuperStar/Game/Code/InGame/Component/Renderer/InGameRendererBaseComponent.cpp
@@ -24,7 +24,7 @@ namespace InGame
         // 座標情報を持つコンポーネントのハンドルを取得
         // このコンポーネントがないと処理できない
         auto [h, c] =
-            this->Owner()->GetComponentHandleAndComponent(&Actor::TransformComponent::CLASS_RTTI);
+            this->Owner()->GetComponentHandleAndComponent(&Actor::TransformComponent::StaticRTTI());
         HE_ASSERT(h.Null() == FALSE);
         this->_transformHandle = h;
 

--- a/SuperStar/HobbyEngine/Inc/Engine/Generated.h
+++ b/SuperStar/HobbyEngine/Inc/Engine/Generated.h
@@ -4,28 +4,31 @@
 
 // RTTIを付与する基本クラスの宣言にRTTI情報を付与するマクロ
 // nameにはクラス型を指定
-#define HE_GENERATED_CLASS_BASE_BODY_HEADER(name)                                               \
-public:                                                                                         \
-    static inline const Core::Common::RTTI CLASS_RTTI = Core::Common::RTTI(HE_STR_TEXT(#name)); \
-                                                                                                \
-public:                                                                                         \
-    const Core::Common::RTTI& VGetRTTI()                                                        \
-    {                                                                                           \
-        return name::CLASS_RTTI;                                                                \
+#define HE_GENERATED_CLASS_BASE_BODY_HEADER(name) \
+public: \
+    static inline const Core::Common::RTTI kRtti_##name = \
+        Core::Common::RTTI(HE_STR_TEXT(#name)); \
+    static const Core::Common::RTTI& StaticRTTI() \
+    { \
+        return kRtti_##name; \
+    } \
+public: \
+    const Core::Common::RTTI& VGetRTTI() \
+    { \
+        return name::StaticRTTI(); \
     }
-
-// RTTIを付与した基本クラスを継承したクラスの宣言にRTTI情報を付与するマクロ
-// nameにはクラス型を指定
-#define HE_GENERATED_CLASS_BODY_HEADER(name, parentName)                \
-public:                                                                 \
-    static inline const Core::Common::RTTI CLASS_RTTI =                 \
-        Core::Common::RTTI(HE_STR_TEXT(#name), parentName::CLASS_RTTI); \
-                                                                        \
-public:                                                                 \
-    const Core::Common::RTTI& VGetRTTI()                                \
-    {                                                                   \
-        return name::CLASS_RTTI;                                        \
+#define HE_GENERATED_CLASS_BODY_HEADER(name, parentName) \
+public: \
+    static inline const Core::Common::RTTI kRtti_##name = \
+        Core::Common::RTTI(HE_STR_TEXT(#name), parentName::StaticRTTI()); \
+    static const Core::Common::RTTI& StaticRTTI() \
+    { \
+        return kRtti_##name; \
+    } \
+public: \
+    const Core::Common::RTTI& VGetRTTI() \
+    { \
+        return name::StaticRTTI(); \
     }
-
 #define HE_GENERATED_CHECK_RTTI(rtti, checkRtti) \
-    ((rtti).VGetRTTI().DerivesFrom(&checkRtti::CLASS_RTTI))
+    ((rtti).VGetRTTI().DerivesFrom(&checkRtti::StaticRTTI()))

--- a/SuperStar/HobbyPlugin/Actor/Inc/Actor/Actor.h
+++ b/SuperStar/HobbyPlugin/Actor/Inc/Actor/Actor.h
@@ -223,7 +223,7 @@ namespace Actor
             HE_STATIC_ASSERT(std::is_base_of<Component, T>::value,
                              "TクラスはComponentクラスを継承していない");
 
-            auto [handle, p] = this->GetComponentHandleAndComponent(&T::CLASS_RTTI);
+            auto [handle, p] = this->GetComponentHandleAndComponent(&T::StaticRTTI());
             if (handle.Null()) return NULL;
 
             return reinterpret_cast<T*>(p);

--- a/SuperStar/HobbyPlugin/EnhancedInput/EnhancedInput/Actor/ActorManagerDecorater.cpp
+++ b/SuperStar/HobbyPlugin/EnhancedInput/EnhancedInput/Actor/ActorManagerDecorater.cpp
@@ -23,7 +23,7 @@ namespace EnhancedInput
     {
         HE_ASSERT(in_pComponent);
 
-        if (in_pComponent->VGetRTTI().DerivesFrom(&InputComponent::CLASS_RTTI) == FALSE) return;
+        if (in_pComponent->VGetRTTI().DerivesFrom(&InputComponent::StaticRTTI()) == FALSE) return;
 
         auto pInputComponent = reinterpret_cast<InputComponent*>(in_pComponent);
         this->_lstInputComponent.PushBack(*pInputComponent);
@@ -33,7 +33,7 @@ namespace EnhancedInput
         Actor::Component* in_pComponent)
     {
         HE_ASSERT(in_pComponent);
-        if (in_pComponent->VGetRTTI().DerivesFrom(&InputComponent::CLASS_RTTI) == FALSE) return;
+        if (in_pComponent->VGetRTTI().DerivesFrom(&InputComponent::StaticRTTI()) == FALSE) return;
 
         auto pInputComponent = reinterpret_cast<InputComponent*>(in_pComponent);
         this->_lstInputComponent.Erase(pInputComponent);

--- a/SuperStar/HobbyPlugin/UI/UI/Component/Input/UIInputRouter.cpp
+++ b/SuperStar/HobbyPlugin/UI/UI/Component/Input/UIInputRouter.cpp
@@ -24,7 +24,7 @@ namespace UI
 
         // Widgetアクターに設定しているUIWidgetコンポーネントを全て取得
         Core::Common::FixedStack<Actor::Component*, 128> sWidgetComponent;
-        pWidget->OutputChildrenComponent(&sWidgetComponent, &UIWidgetComponent::CLASS_RTTI);
+        pWidget->OutputChildrenComponent(&sWidgetComponent, &UIWidgetComponent::StaticRTTI());
 
         HE::Uint32 uSize = sWidgetComponent.Size();
         HE_ASSERT_RETURN(0 < uSize);


### PR DESCRIPTION
## Summary
- generate per-class RTTI variable `kRtti_<class>` with new `StaticRTTI` accessor
- update `HE_GENERATED_CHECK_RTTI` and all usages to call `StaticRTTI`

## Testing
- `cmake -S SuperStar -B build` *(fails: Invalid linker flag)*

------
https://chatgpt.com/codex/tasks/task_e_68563700e684832396c9ac77d526439f