### PR TITLE
Add Localization plugin tests

### DIFF
--- a/SuperStar/HobbyPlugin/Localization/Test/.vcpkg.json
+++ b/SuperStar/HobbyPlugin/Localization/Test/.vcpkg.json
@@ -1,0 +1,13 @@
+{
+    "name": "unittest",
+    "version-string": "1.0.0",
+    "dependencies": [
+        "gtest"
+    ],
+    "overrides": [
+        {
+            "name": "gtest",
+            "version": "1.17.0#1"
+        }
+    ]
+}

--- a/SuperStar/HobbyPlugin/Localization/Test/CMakeLists.txt
+++ b/SuperStar/HobbyPlugin/Localization/Test/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.26)
+
+include(${CMAKE_SOURCE_DIR}/HobbyEngine/cmake/VCPkg.cmake NO_POLICY_SCOPE)
+include(${CMAKE_SOURCE_DIR}/HobbyEngine/cmake/Project.cmake NO_POLICY_SCOPE)
+include(${CMAKE_SOURCE_DIR}/HobbyEngine/cmake/Test.cmake NO_POLICY_SCOPE)
+include(${CMAKE_SOURCE_DIR}/HobbyPlugin/AssetManager/Config.cmake NO_POLICY_SCOPE)
+include(${CMAKE_SOURCE_DIR}/HobbyPlugin/PlatformSDL2/Config.cmake NO_POLICY_SCOPE)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../Config.cmake NO_POLICY_SCOPE)
+include(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake NO_POLICY_SCOPE)
+
+add_executable(${PLUGIN_LOCALIZATION_TEST_NAME}
+    ${PLUGIN_LOCALIZATION_TARGET_TEST_SRC_FILES}
+)
+
+project_configure_target(${PLUGIN_LOCALIZATION_TEST_NAME})
+
+project_configure_files_target(${PLUGIN_LOCALIZATION_TEST_NAME}
+    ${PLUGIN_LOCALIZATION_TARGET_TEST_SRC_FILES}
+)
+
+vcpkg_install_package(${CMAKE_CURRENT_SOURCE_DIR} "x64-windows-static")
+
+test_configure_target(
+    ${PLUGIN_LOCALIZATION_TEST_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/VcPkg/x64-windows-static
+    ${PLUGIN_ASSET_MANAGER_NAME}
+    ${PLUGIN_PLATFORMSDL2_NAME}
+    ${LOCALIZATION_PLUGIN_NAME}
+)
+
+add_custom_command(
+    TARGET ${PLUGIN_LOCALIZATION_TEST_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/Resources"
+            "$<TARGET_FILE_DIR:${PLUGIN_LOCALIZATION_TEST_NAME}>/Resources"
+    COMMENT "Copying Resources to output dir"
+)

--- a/SuperStar/HobbyPlugin/Localization/Test/Config.cmake
+++ b/SuperStar/HobbyPlugin/Localization/Test/Config.cmake
@@ -1,0 +1,5 @@
+set(PLUGIN_LOCALIZATION_TEST_NAME HobbyPlugin_Localization_UnitTests)
+
+set(PLUGIN_LOCALIZATION_TARGET_TEST_SRC_FILES
+    Localization/LocalizationModuleTest.cpp
+)

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.json
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.json
@@ -1,0 +1,10 @@
+{
+    "version": 1,
+    "data": {
+        "player_default": {
+            "hp": 3,
+            "move_speed": 7.0,
+            "invincible_time_sec": 1.5
+        }
+    }
+}

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.toml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.toml
@@ -1,0 +1,18 @@
+# 共通設定
+[config]
+current_dir="Locate"
+
+# 各言語のテキスト情報
+# 日本語の各テキストグループ
+[locate.JP.default]
+json="Text.json"
+
+# デバッグ用のテキスト
+# TODO: リリースの場合はロードしないようにする
+[locate.JP.debug]
+json="Debug.json"
+
+# (Test)英語の各テキストグループ
+[locate.EN.default]
+json="Text.json"
+

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.xml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/File/Test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui id="root">
+  <layer id="DebugLayer" x="0" y="0" style="color: 0x808080FF; w:640; h:480">
+    <btn id="C_TitleSeq" x="50" y="0" style="w: 300; h: 50; color: white;">
+      <label loc="1" text="debug.TitleLevelName" style="color: black;"/>
+    </btn>
+    <btn id="C_PlaySeq" x="50" y="60" style="w: 300; h: 50; color: white;">
+      <label loc="1" text="debug.MainGameLevelName" style="color: black;"/>
+    </btn>
+    <btn id="C_PlaySeq" x="50" y="120" style="w: 300; h: 50; color: white;">
+      <label loc="1" text="debug.LuaTestProcess" style="color: black;"/>
+    </btn>
+  </layer>
+</ui>

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/JP/Debug.json
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/JP/Debug.json
@@ -1,0 +1,57 @@
+{
+    "TitleLevelName": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "タイトル"
+            }
+        }
+    },
+    "MainGameLevelName": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "プレイ"
+            }
+        }
+    },
+    "SpriteTestLevelName": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "スプライトテスト"
+            }
+        }
+    },
+    "BossTestLevelName": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "ボステスト"
+            }
+        }
+    },
+    "LuaTestProcess": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "Luaテスト実行"
+            }
+        }
+    }
+}

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/JP/Text.json
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/JP/Text.json
@@ -1,0 +1,24 @@
+{
+    "GameTitle": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "STG"
+            }
+        }
+    },
+    "GameTitleInputHelp": {
+        "font": "",
+        "size": 10,
+        "color": 0,
+        "items": {
+            "0": {
+                "type": 0,
+                "text": "GAME START: Space Key\nGAME END: a Key"
+            }
+        }
+    }
+}

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/System.toml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Locate/System.toml
@@ -1,0 +1,18 @@
+# 共通設定
+[config]
+current_dir="Locate"
+
+# 各言語のテキスト情報
+# 日本語の各テキストグループ
+[locate.JP.default]
+json="Text.json"
+
+# デバッグ用のテキスト
+# TODO: リリースの場合はロードしないようにする
+[locate.JP.debug]
+json="Debug.json"
+
+# (Test)英語の各テキストグループ
+[locate.EN.default]
+json="Text.json"
+

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Paramater/Test.json
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/Paramater/Test.json
@@ -1,0 +1,10 @@
+{
+    "version": 1,
+    "data": {
+        "player_default": {
+            "hp": 3,
+            "move_speed": 7.0,
+            "invincible_time_sec": 1.5
+        }
+    }
+}

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Game/InGame.xml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Game/InGame.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui id="root">
+  <layer id="Layer" style="color: black;">
+  </layer>
+</ui>

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Game/Title.xml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Game/Title.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui id="root">
+  <layer id="Layer" style="color: black;">
+    <label id="TitleLabel" x="300" y ="200" loc="1" text="default.GameTitle" anchor="center" style="color: white; size: 30;"/>
+    <label id="PushBtnLabel" x="300" y="400" loc="1" text="default.GameTitleInputHelp" anchor="center" style="color: white; size: 20;"/>
+  </layer>
+</ui>

--- a/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Test/Launcher.xml
+++ b/SuperStar/HobbyPlugin/Localization/Test/Resources/Assets/UI/Builder/Test/Launcher.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui id="root">
+  <layer id="DebugLayer" x="0" y="0" style="color: 0x808080FF; w:640; h:480">
+    <btn id="C_TitleSeq" x="50" y="0" input="OnClickLeft" style="w: 300; h: 50; color: white;">
+      <label id="TitleName" loc="1" text="debug.TitleLevelName" style="color: black;"/>
+    </btn>
+    <btn id="C_PlaySeq" x="50" y="60" input="OnClickLeft" style="w: 300; h: 50; color: white;">
+      <label id="GameName" loc="1" text="debug.MainGameLevelName" style="color: black;"/>
+    </btn>
+    <btn id="C_LuaSeq" x="50" y="120" input="OnClickLeft" style="w: 300; h: 50; color: white;">
+      <label id="LuaTest" loc="1" text="debug.LuaTestProcess" style="color: black;"/>
+    </btn>
+  </layer>
+</ui>


### PR DESCRIPTION
## Summary
- add Localization plugin test configuration and resources
- create vcpkg file for Localization tests
- include AssetManager and PlatformSDL2 linking
- remove binary font/image resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ec47785083239cbbc9ec8fd2e0b5