### PR TITLE
Fix Particle namespace typo

### DIFF
--- a/SuperStar/HobbyPlugin/Render/Render/Particle/Blob.cpp
+++ b/SuperStar/HobbyPlugin/Render/Render/Particle/Blob.cpp
@@ -2,7 +2,7 @@
 
 #include "./../Command/Command.h"
 
-namespace Render::Prticle
+namespace Render::Particle
 {
     Blob::Blob(Core::Common::Handle in_renderHandle,
                Core::Memory::UniquePtr<CreateFunctionType> in_upCreateFunc,
@@ -61,4 +61,4 @@ namespace Render::Prticle
         // TODO: パーティクルの色を書き込む
     }
 
-}  // namespace Render::Prticle
+}  // namespace Render::Particle

--- a/SuperStar/HobbyPlugin/Render/Render/Particle/Blob.h
+++ b/SuperStar/HobbyPlugin/Render/Render/Particle/Blob.h
@@ -5,7 +5,7 @@
 #include "Engine/Math/Math.h"
 #include "Engine/MiniEngine.h"
 
-namespace Render::Prticle
+namespace Render::Particle
 {
     /// <summary>
     /// 粒子データ
@@ -73,4 +73,4 @@ namespace Render::Prticle
         Core::Memory::UniquePtr<PositionFunctionType> _upPositionFunc;
         Core::Memory::UniquePtr<VelocityFunctionType> _upVelocityFunc;
     };
-}  // namespace Render::Prticle
+}  // namespace Render::Particle

--- a/SuperStar/HobbyPlugin/Render/Render/Window/Scene.cpp
+++ b/SuperStar/HobbyPlugin/Render/Render/Window/Scene.cpp
@@ -22,7 +22,7 @@ namespace Render
         HE_SAFE_DELETE_UNIQUE_PTR(this->_upSt);
     }
 
-    const Render::Prticle::Blob& SceneViewBase::GetPrticle(const Core::Common::Handle in_handle)
+    const Render::Particle::Blob& SceneViewBase::GetPrticle(const Core::Common::Handle in_handle)
     {
         return *(this->_runtimePoolPrticleBlob.Ref(in_handle));
     }

--- a/SuperStar/HobbyPlugin/Render/Render/Window/Scene.h
+++ b/SuperStar/HobbyPlugin/Render/Render/Window/Scene.h
@@ -11,7 +11,7 @@ namespace Platform
     struct ViewPortConfig;
 }  // namespace Platform
 
-namespace Render::Prticle
+namespace Render::Particle
 {
     class Blob;
 }
@@ -28,7 +28,7 @@ namespace Render
         friend class Window;
         friend class RenderModule;
 
-        using RuntimePoolPricleBlob = Core::Common::RuntimePoolManager<Render::Prticle::Blob>;
+        using RuntimePoolPricleBlob = Core::Common::RuntimePoolManager<Render::Particle::Blob>;
 
     public:
         SceneViewBase();
@@ -37,7 +37,7 @@ namespace Render
         HE::Bool Init(Core::Memory::UniquePtr<Platform::SceneStrategyInterface>);
         void Release();
 
-        const Render::Prticle::Blob& GetPrticle(const Core::Common::Handle);
+        const Render::Particle::Blob& GetPrticle(const Core::Common::Handle);
 
     protected:
         void _Begin();

--- a/SuperStar/HobbyPlugin/Render/RenderModule.cpp
+++ b/SuperStar/HobbyPlugin/Render/RenderModule.cpp
@@ -186,7 +186,7 @@ namespace Render
 
         // パーティクル描画ハンドルを生成
         auto upCreateParticlaHandler =
-            HE_MAKE_CUSTOM_UNIQUE_PTR((Render::Prticle::Blob::CreateFunctionType),
+            HE_MAKE_CUSTOM_UNIQUE_PTR((Render::Particle::Blob::CreateFunctionType),
                                       [this](HE::Uint32 in_uCount)
                                       {
                                           auto pPlatform =
@@ -195,7 +195,7 @@ namespace Render
                                       });
 
         auto upDeleteParticleHandler =
-            HE_MAKE_CUSTOM_UNIQUE_PTR((Render::Prticle::Blob::DeleteFunctionType),
+            HE_MAKE_CUSTOM_UNIQUE_PTR((Render::Particle::Blob::DeleteFunctionType),
                                       [this](Core::Common::Handle in_rHandle)
                                       {
                                           auto pPlatform =
@@ -204,7 +204,7 @@ namespace Render
                                       });
 
         auto upPositionHandler = HE_MAKE_CUSTOM_UNIQUE_PTR(
-            (Render::Prticle::Blob::PositionFunctionType),
+            (Render::Particle::Blob::PositionFunctionType),
             [this](const Core::Common::Handle in_handle,
                    const Core::Common::ArrayBase<Core::Math::Vector3>& in_arPosition)
             {
@@ -213,7 +213,7 @@ namespace Render
             });
 
         auto upVelocityHandler = HE_MAKE_CUSTOM_UNIQUE_PTR(
-            (Render::Prticle::Blob::VelocityFunctionType),
+            (Render::Particle::Blob::VelocityFunctionType),
             [this](const Core::Common::Handle in_handle,
                    const Core::Common::ArrayBase<Core::Math::Vector3>& in_arVelocity)
             {
@@ -221,7 +221,7 @@ namespace Render
                 pPlatform->VScreen()->VParticalSetVelocitys(in_handle, in_arVelocity);
             });
 
-        auto [handle, pBlob] = pScene->_runtimePoolPrticleBlob.Alloc<Render::Prticle::Blob>(
+        auto [handle, pBlob] = pScene->_runtimePoolPrticleBlob.Alloc<Render::Particle::Blob>(
             in_renderHandle, std::move(upCreateParticlaHandler), std::move(upDeleteParticleHandler),
             std::move(upPositionHandler), std::move(upVelocityHandler));
         this->_mParticleHandle[handle] = pBlob;
@@ -247,7 +247,7 @@ namespace Render
         pScene->_runtimePoolPrticleBlob.Free(in_rPrticleHandle, FALSE);
     }
 
-    Render::Prticle::Blob& RenderModule::GetPrticle(const Core::Common::Handle in_prticleHandle)
+    Render::Particle::Blob& RenderModule::GetPrticle(const Core::Common::Handle in_prticleHandle)
     {
         HE_ASSERT(in_prticleHandle.Null() == FALSE);
 

--- a/SuperStar/HobbyPlugin/Render/RenderModule.h
+++ b/SuperStar/HobbyPlugin/Render/RenderModule.h
@@ -48,7 +48,7 @@ namespace Render
     public:
         using ViewHandleVector   = Core::Common::FixedVector<Core::Common::Handle, 32>;
         using WindowHandleKeyMap = Core::Common::FixedMap<HE::Uint64, Core::Common::Handle, 32>;
-        using ParticleBlobObject = std::tuple<Core::Common::Handle, Render::Prticle::Blob*>;
+        using ParticleBlobObject = std::tuple<Core::Common::Handle, Render::Particle::Blob*>;
 
         using OnFactoryWindowStrategyCallback =
             std::function<Core::Memory::UniquePtr<Platform::WindowStrategy>(
@@ -119,7 +119,7 @@ namespace Render
         /// <summary>
         /// 生成したパーティクルを取得
         /// </summary>
-        Render::Prticle::Blob& GetPrticle(const Core::Common::Handle);
+        Render::Particle::Blob& GetPrticle(const Core::Common::Handle);
 
         /// <summary>
         /// レンダリングするコマンド追加
@@ -165,7 +165,7 @@ namespace Render
 
         Core::Common::FixedStack<Core::Common::Handle, 32> _sStandupWindow;
         // TODO: 自前のを作ったら差し替える
-        std::unordered_map<Core::Common::Handle, Render::Prticle::Blob*> _mParticleHandle;
+        std::unordered_map<Core::Common::Handle, Render::Particle::Blob*> _mParticleHandle;
     };
 
 }  // namespace Render


### PR DESCRIPTION
## Summary
- fix Render::Particle namespace typos across plugin sources

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686a4fcef3408323a36586bafcdfef83